### PR TITLE
Add re-raise to exeption for higher level handling

### DIFF
--- a/src/hoprd/wrapper.py
+++ b/src/hoprd/wrapper.py
@@ -14,7 +14,7 @@ class HoprdAPI(object):
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         pass
 
-    async def safe_api(self, path, method, data: bytes, timeout=600.0):
+    async def _safe_call_api(self, path, method, data: bytes, timeout=600.0):
         async with httpx.AsyncClient(timeout=timeout) as client:
             request = httpx.Request(
                 method,
@@ -30,7 +30,7 @@ class HoprdAPI(object):
             return response
 
     async def call_api(self, path, method, data: bytes, timeout=600.0):
-        response = await self.safe_api(path, method, data, timeout)
+        response = await self._safe_call_api(path, method, data, timeout)
 
         try:
             response.raise_for_status()
@@ -48,39 +48,39 @@ class HoprdAPI(object):
                 "recipient": f"{recipient}",
             }
         )
-        return await self.safe_api("account/withdraw", "POST", bytes(data, "utf-8"))
+        return await self._safe_call_api("account/withdraw", "POST", bytes(data, "utf-8"))
 
     async def balance(self):
         data = json.dumps({})
-        return await self.safe_api("account/balances", "GET", bytes(data, "utf-8"))
+        return await self._safe_call_api("account/balances", "GET", bytes(data, "utf-8"))
 
     async def set_alias(self, peer_id, alias):
         data = json.dumps({"peerId": f"{peer_id}", "alias": f"{alias}"})
-        return await self.safe_api("aliases", "POST", bytes(data, "utf-8"))
+        return await self._safe_call_api("aliases", "POST", bytes(data, "utf-8"))
 
     async def get_alias(self, alias):
         data = json.dumps({})
-        return await self.safe_api(f"aliases/{alias}", "GET", bytes(data, "utf-8"))
+        return await self._safe_call_api(f"aliases/{alias}", "GET", bytes(data, "utf-8"))
 
     async def remove_alias(self, alias):
         data = json.dumps({})
-        return await self.safe_api(f"aliases/{alias}", "DELETE", bytes(data, "utf-8"))
+        return await self._safe_call_api(f"aliases/{alias}", "DELETE", bytes(data, "utf-8"))
 
     async def get_aliases(self):
         data = json.dumps({})
-        return await self.safe_api("aliases", "GET", bytes(data, "utf-8"))
+        return await self._safe_call_api("aliases", "GET", bytes(data, "utf-8"))
 
     async def set_setting(self, key, value):
         data = json.dumps({"settingValue": f"{value}"})
-        return await self.safe_api(f"settings/{key}", "GET", bytes(data, "utf-8"))
+        return await self._safe_call_api(f"settings/{key}", "GET", bytes(data, "utf-8"))
 
     async def get_settings(self):
         data = json.dumps({})
-        return await self.safe_api("settings", "GET", bytes(data, "utf-8"))
+        return await self._safe_call_api("settings", "GET", bytes(data, "utf-8"))
 
     async def get_all_channels(self, include_closed: bool):
         data = json.dumps({})
-        return await self.safe_api(f"/channels?includingClosed=${include_closed}", "GET", bytes(data, "utf-8"))
+        return await self._safe_call_api(f"/channels?includingClosed=${include_closed}", "GET", bytes(data, "utf-8"))
 
     async def get_channel_topology(self, full_topology: bool):
         """
@@ -95,21 +95,21 @@ class HoprdAPI(object):
             The response from the API call.
         """
         data = json.dumps({})
-        return await self.safe_api(f"channels?fullTopology={str(full_topology).lower()}", "GET", bytes(data, "utf-8"))
+        return await self._safe_call_api(f"channels?fullTopology={str(full_topology).lower()}", "GET", bytes(data, "utf-8"))
 
     async def get_tickets_in_channel(self, include_closed: bool):
         data = json.dumps({})
-        return await self.safe_api(f"/channels?includingClosed=${include_closed}", "GET", bytes(data, "utf-8"))
+        return await self._safe_call_api(f"/channels?includingClosed=${include_closed}", "GET", bytes(data, "utf-8"))
 
     async def redeem_tickets_in_channel(self, peer_id):
         """Redeeming tickets can take up to 5 minutes"""
         data = json.dumps({})
-        return await self.safe_api(f"/channels/{peer_id}/tickets/redeem", "POST", bytes(data, "utf-8"))
+        return await self._safe_call_api(f"/channels/{peer_id}/tickets/redeem", "POST", bytes(data, "utf-8"))
 
     async def redeem_tickets(self):
         """Redeeming tickets can take up to 5 minutes"""
         data = json.dumps({})
-        return await self.safe_api("tickets/redeem", "POST", bytes(data, "utf-8"))
+        return await self._safe_call_api("tickets/redeem", "POST", bytes(data, "utf-8"))
 
     async def ping(self, peer_id):
         data = json.dumps(
@@ -117,7 +117,7 @@ class HoprdAPI(object):
                 "peerId": f"{peer_id}",
             }
         )
-        return await self.safe_api("node/ping", "POST", bytes(data, "utf-8"))
+        return await self._safe_call_api("node/ping", "POST", bytes(data, "utf-8"))
 
     async def peers(self, **kwargs):
         """
@@ -130,14 +130,14 @@ class HoprdAPI(object):
         """
         data = json.dumps({})
         args = "?" + "&".join([f"{key}={value}" for key, value in kwargs.items()]) if kwargs else ""
-        return await self.safe_api(f"node/peers{args}", "GET", bytes(data, "utf-8"))
+        return await self._safe_call_api(f"node/peers{args}", "GET", bytes(data, "utf-8"))
 
     async def get_address(self):
         data = json.dumps({})
-        return await self.safe_api("account/addresses", "GET", bytes(data, "utf-8"))
+        return await self._safe_call_api("account/addresses", "GET", bytes(data, "utf-8"))
 
     async def send_message(self, destination, message, hops):
         assert isinstance(hops, list)
 
         data = json.dumps({"body": message, "path": hops, "recipient": destination})
-        return await self.safe_api("messages", "POST", bytes(data, "utf-8"))
+        return await self._safe_call_api("messages", "POST", bytes(data, "utf-8"))

--- a/src/hoprd/wrapper.py
+++ b/src/hoprd/wrapper.py
@@ -14,7 +14,7 @@ class HoprdAPI(object):
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         pass
 
-    async def call_api(self, path, method, data: bytes, timeout=600.0):
+    async def safe_api(self, path, method, data: bytes, timeout=600.0):
         async with httpx.AsyncClient(timeout=timeout) as client:
             request = httpx.Request(
                 method,
@@ -29,8 +29,8 @@ class HoprdAPI(object):
             response = await client.send(request)
             return response
 
-    async def _safe_call_api(self, path, method, data: bytes, timeout=600.0):
-        response = await self.call_api(path, method, data, timeout)
+    async def call_api(self, path, method, data: bytes, timeout=600.0):
+        response = await self.safe_api(path, method, data, timeout)
 
         try:
             response.raise_for_status()
@@ -48,39 +48,39 @@ class HoprdAPI(object):
                 "recipient": f"{recipient}",
             }
         )
-        return await self.call_api("account/withdraw", "POST", bytes(data, "utf-8"))
+        return await self.safe_api("account/withdraw", "POST", bytes(data, "utf-8"))
 
     async def balance(self):
         data = json.dumps({})
-        return await self.call_api("account/balances", "GET", bytes(data, "utf-8"))
+        return await self.safe_api("account/balances", "GET", bytes(data, "utf-8"))
 
     async def set_alias(self, peer_id, alias):
         data = json.dumps({"peerId": f"{peer_id}", "alias": f"{alias}"})
-        return await self.call_api("aliases", "POST", bytes(data, "utf-8"))
+        return await self.safe_api("aliases", "POST", bytes(data, "utf-8"))
 
     async def get_alias(self, alias):
         data = json.dumps({})
-        return await self.call_api(f"aliases/{alias}", "GET", bytes(data, "utf-8"))
+        return await self.safe_api(f"aliases/{alias}", "GET", bytes(data, "utf-8"))
 
     async def remove_alias(self, alias):
         data = json.dumps({})
-        return await self.call_api(f"aliases/{alias}", "DELETE", bytes(data, "utf-8"))
+        return await self.safe_api(f"aliases/{alias}", "DELETE", bytes(data, "utf-8"))
 
     async def get_aliases(self):
         data = json.dumps({})
-        return await self.call_api("aliases", "GET", bytes(data, "utf-8"))
+        return await self.safe_api("aliases", "GET", bytes(data, "utf-8"))
 
     async def set_setting(self, key, value):
         data = json.dumps({"settingValue": f"{value}"})
-        return await self.call_api(f"settings/{key}", "GET", bytes(data, "utf-8"))
+        return await self.safe_api(f"settings/{key}", "GET", bytes(data, "utf-8"))
 
     async def get_settings(self):
         data = json.dumps({})
-        return await self.call_api("settings", "GET", bytes(data, "utf-8"))
+        return await self.safe_api("settings", "GET", bytes(data, "utf-8"))
 
     async def get_all_channels(self, include_closed: bool):
         data = json.dumps({})
-        return await self.call_api(f"/channels?includingClosed=${include_closed}", "GET", bytes(data, "utf-8"))
+        return await self.safe_api(f"/channels?includingClosed=${include_closed}", "GET", bytes(data, "utf-8"))
 
     async def get_channel_topology(self, full_topology: bool):
         """
@@ -95,21 +95,21 @@ class HoprdAPI(object):
             The response from the API call.
         """
         data = json.dumps({})
-        return await self.call_api(f"channels?fullTopology={str(full_topology).lower()}", "GET", bytes(data, "utf-8"))
+        return await self.safe_api(f"channels?fullTopology={str(full_topology).lower()}", "GET", bytes(data, "utf-8"))
 
     async def get_tickets_in_channel(self, include_closed: bool):
         data = json.dumps({})
-        return await self.call_api(f"/channels?includingClosed=${include_closed}", "GET", bytes(data, "utf-8"))
+        return await self.safe_api(f"/channels?includingClosed=${include_closed}", "GET", bytes(data, "utf-8"))
 
     async def redeem_tickets_in_channel(self, peer_id):
         """Redeeming tickets can take up to 5 minutes"""
         data = json.dumps({})
-        return await self.call_api(f"/channels/{peer_id}/tickets/redeem", "POST", bytes(data, "utf-8"))
+        return await self.safe_api(f"/channels/{peer_id}/tickets/redeem", "POST", bytes(data, "utf-8"))
 
     async def redeem_tickets(self):
         """Redeeming tickets can take up to 5 minutes"""
         data = json.dumps({})
-        return await self.call_api("tickets/redeem", "POST", bytes(data, "utf-8"))
+        return await self.safe_api("tickets/redeem", "POST", bytes(data, "utf-8"))
 
     async def ping(self, peer_id):
         data = json.dumps(
@@ -117,7 +117,7 @@ class HoprdAPI(object):
                 "peerId": f"{peer_id}",
             }
         )
-        return await self.call_api("node/ping", "POST", bytes(data, "utf-8"))
+        return await self.safe_api("node/ping", "POST", bytes(data, "utf-8"))
 
     async def peers(self, **kwargs):
         """
@@ -130,14 +130,14 @@ class HoprdAPI(object):
         """
         data = json.dumps({})
         args = "?" + "&".join([f"{key}={value}" for key, value in kwargs.items()]) if kwargs else ""
-        return await self.call_api(f"node/peers{args}", "GET", bytes(data, "utf-8"))
+        return await self.safe_api(f"node/peers{args}", "GET", bytes(data, "utf-8"))
 
     async def get_address(self):
         data = json.dumps({})
-        return await self.call_api("account/addresses", "GET", bytes(data, "utf-8"))
+        return await self.safe_api("account/addresses", "GET", bytes(data, "utf-8"))
 
     async def send_message(self, destination, message, hops):
         assert isinstance(hops, list)
 
         data = json.dumps({"body": message, "path": hops, "recipient": destination})
-        return await self.call_api("messages", "POST", bytes(data, "utf-8"))
+        return await self.safe_api("messages", "POST", bytes(data, "utf-8"))

--- a/src/hoprd/wrapper.py
+++ b/src/hoprd/wrapper.py
@@ -31,6 +31,7 @@ class HoprdAPI(object):
                 response.raise_for_status()
             except httpx.HTTPError as exc:
                 logging.error(f"HTTP Exception for {exc.request.url} - {exc}")
+                raise exc
             finally:
                 return response
 

--- a/src/hoprd/wrapper.py
+++ b/src/hoprd/wrapper.py
@@ -26,14 +26,19 @@ class HoprdAPI(object):
                 content=data,
             )
 
-            try:
-                response = await client.send(request)
-                response.raise_for_status()
-            except httpx.HTTPError as exc:
-                logging.error(f"HTTP Exception for {exc.request.url} - {exc}")
-                raise exc
-            finally:
-                return response
+            response = await client.send(request)
+            return response
+
+    async def _safe_call_api(self, path, method, data: bytes, timeout=600.0):
+        response = await self.call_api(path, method, data, timeout)
+
+        try:
+            response.raise_for_status()
+        except httpx.HTTPError as exc:
+            logging.error(f"HTTP Exception for {exc.request.url} - {exc}")
+            raise exc
+        finally:
+            return response
 
     async def withdraw(self, currency, amount, recipient):
         data = json.dumps(


### PR DESCRIPTION
The call_api() method handles httpx exceptions, but the exceptions need to be re-raised, to that they can be managed on a higher level.