### PR TITLE
Change package name

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@
 
 from setuptools import setup, find_packages  # noqa: H301
 
-NAME = "swagger-client"
+NAME = "hoprd-api-python"
 VERSION = "1.0.0"
 # To install the library, run the following
 #

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@
 
 from setuptools import setup, find_packages  # noqa: H301
 
-NAME = "hoprd-api-python"
+NAME = "hoprd-api-client"
 VERSION = "1.0.0"
 # To install the library, run the following
 #


### PR DESCRIPTION
The previous name was very generic. Using `hoprd-api-client` now instead.